### PR TITLE
feat: migrate from Lens to Freelens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,31 @@
-FROM ubuntu:20.04
-ARG LENS_VERSION
+# Use Ubuntu as the base image
+FROM ubuntu:plucky
+
+ARG FREELENS_VERSION
 
 ENV DISPLAY=:0
 ENV PORT=8080
-ENV DEBIAN_FRONTEND=noninteractive
 
-COPY --from=mattipaksula/wait-for:sha-2a34cde /wait-for /usr/bin
-
+# Install dependencies
 RUN apt-get update && apt-get install -y \
-  curl git \
-  xvfb x11vnc \
-  libnss3 libglib2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libx11-xcb1 libasound2 libxss1 libgbm1 \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-  && apt-get update && apt-get install -y nodejs
+  curl git xvfb x11vnc nodejs npm libarchive-tools wget libnss3 libgdk libgbm1 libglib2 libxss1 libgtk-3-0 libatspi2.0-0 libsecret-1-0 libasound2t64 && \
+  apt-get clean
 
 WORKDIR /opt
-RUN git clone https://github.com/novnc/websockify-js.git \
-  && cd websockify-js/websockify && npm install
 
-RUN curl -LO https://github.com/lensapp/lens/releases/download/v${LENS_VERSION}/Lens-${LENS_VERSION}.AppImage \
-  && chmod +x Lens-${LENS_VERSION}.AppImage \
-  && ./Lens-${LENS_VERSION}.AppImage --appimage-extract \
-  && rm -rf Lens-${LENS_VERSION}.AppImage \
-  && mv /opt/squashfs-root /opt/lens
+# Clone and install websockify-js
+RUN git clone https://github.com/novnc/websockify-js.git && \
+  cd websockify-js/websockify && \
+  npm install
+
+# Download and install Freelens .deb package
+RUN wget https://github.com/freelensapp/freelens/releases/download/v${FREELENS_VERSION}/Freelens-${FREELENS_VERSION}-linux-amd64.deb && \
+  dpkg -i Freelens-${FREELENS_VERSION}-linux-amd64.deb && \
+  rm -f Freelens-${FREELENS_VERSION}-linux-amd64.deb
 
 WORKDIR /app
+
+# Copy application code
 COPY app .
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lens-web
+* # lens-web
 
 [https://github.com/lensapp/lens](https://github.com/lensapp/lens) for browser sponsored by [https://www.supervisor.com](https://www.supervisor.com)
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 _term() {
   echo "bye"
@@ -10,33 +11,37 @@ trap _term TERM INT
 
 mkdir -p /root/.kube
 
+echo "Starting Xvfb..."
 (
-  >/dev/null 2>&1 rm /tmp/.X0-lock || true
+  rm -f /tmp/.X0-lock || true
   exec Xvfb :0 -screen 0 1366x768x24 -ac -listen tcp
-) >/tmp/xvfb.log 2>&1 &
+) &
 echo $! >/tmp/xvfb.pid
 
 
+echo "Starting x11vnc..."
 (
   wait-for localhost:6000
   exec x11vnc -display :0 -shared -nopw -forever
-) >/tmp/x11vnc.log 2>&1 &
+) &
 echo $! >/tmp/x11vnc.pid
 
+echo "Starting websockify-js..."
 (
   wait-for localhost:5900
-  exec node /opt/websockify-js/websockify/websockify.js  --web /app/public ":$PORT" 127.0.0.1:5900
-) >/tmp/websockify.js 2>&1 &
+  exec node /opt/websockify-js/websockify/websockify.js --web /app/public --websockify-path /websockify ":$PORT" 127.0.0.1:5900
+) &
 websockify_pid=$!
 
+echo "Starting Freelens..."
 (
-  cd /opt/lens
+  cd /opt/Freelens
   while true; do
-    ./kontena-lens --no-sandbox
+    ls -a
+    ./freelens --no-sandbox
   done
-) >/tmp/lens.log 2>&1 &
+) &
 echo $! >/tmp/lens.pid
 
 echo "listening at port :$PORT"
-tail -f /dev/null &
-wait $!
+wait

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: "3.7"
-
+---
 services:
   app:
     build:
       context: .
       args:
-        - LENS_VERSION=3.6.7
-    image: ${IMAGE:-supervisorcom/lens-web}
+        - FREELENS_VERSION=1.2.0
     ports:
       - 5900:5900
       - 8080:8080


### PR DESCRIPTION
- Replace Lens AppImage with Freelens .deb package installation
- Update Dockerfile to use Ubuntu plucky as base image
- Add new dependencies required by Freelens
- Modify entrypoint.sh to handle Freelens processes
- Update docker-compose.yml with Freelens version

This change represents a complete migration from Lens to Freelens as the primary application, including all necessary container configuration updates to support the new package format.